### PR TITLE
39 remove punctuation closes #39

### DIFF
--- a/app/models/black_list.rb
+++ b/app/models/black_list.rb
@@ -14,8 +14,14 @@ class BlackList < Global::BlackList
     finder.raw_possibilities.each do |source, content|
       temp = content.pop.split(" ")
       content = content + (temp.uniq - black_list)
-      post_black_list[source] = content
+      post_black_list[source] = remove_punctuation(content)
     end
     post_black_list
+  end
+
+  private
+
+  def remove_punctuation(content)
+    content.map { |phrase| phrase.gsub(/[^a-zA-Z ]*/, "") }
   end
 end

--- a/app/models/black_list.rb
+++ b/app/models/black_list.rb
@@ -10,9 +10,8 @@ class BlackList < Global::BlackList
   end
 
   def prepare
-    raw = finder.raw_possibilities
     post_black_list = {}
-    raw.each do |source, content|
+    finder.raw_possibilities.each do |source, content|
       temp = content.pop.split(" ")
       content = content + (temp.uniq - black_list)
       post_black_list[source] = content

--- a/app/models/creator.rb
+++ b/app/models/creator.rb
@@ -7,7 +7,7 @@ class Creator
 
   def prepare
     possibles = []
-    finder.raw_content.each do |source, content|
+    finder.raw_possibilities.each do |source, content|
       content.each do |phrase|
         possibles << Possibility.find_or_create_by(source: source, title: phrase)
       end

--- a/app/models/creator.rb
+++ b/app/models/creator.rb
@@ -6,9 +6,8 @@ class Creator
   end
 
   def prepare
-    raw = finder.raw_possibilities
     possibles = []
-    raw.each do |source, content|
+    finder.raw_content.each do |source, content|
       content.each do |phrase|
         possibles << Possibility.find_or_create_by(source: source, title: phrase)
       end

--- a/app/models/possibility_finder.rb
+++ b/app/models/possibility_finder.rb
@@ -1,26 +1,16 @@
 class PossibilityFinder
   attr_reader :idea_type,
               :current_user
+  attr_accessor :raw_possibilities
 
   def initialize(idea_type, current_user)
     @idea_type = idea_type
     @current_user = current_user if current_user
+    @raw_possibilities ||= get_raw_content
   end
 
   def possibilities
     prepare_all
-  end
-
-  def raw_possibilities
-    if @raw_possibilities
-      @raw_possibilities
-    else
-      @raw_possibilities = {}
-      services.each do |service|
-        @raw_possibilities = @raw_possibilities.merge(service.raw_possibilities)
-        @raw_possibilities.each_value { |content| content.downcase! }
-      end
-    end
   end
 
   def black_listed
@@ -37,11 +27,19 @@ class PossibilityFinder
     ServicesFinder.new(idea_type).services
   end
 
+  def get_raw_content
+    raw_content = {}
+    services.each do |service|
+      raw_content = raw_content.merge(service.raw_possibilities)
+      raw_content.each_value { |content| content.downcase! }
+    end
+    raw_content
+  end
+
   def prepare_all
-    raw_possibilities
     [WhiteList, BlackList, Creator].each do |worker|
       @raw_possibilities = worker.new(self).prepare
     end
-    @raw_possibilities.shuffle
+    raw_possibilities.shuffle
   end
 end

--- a/app/models/white_list.rb
+++ b/app/models/white_list.rb
@@ -10,9 +10,8 @@ class WhiteList < Global::WhiteList
   end
 
   def prepare
-    raw = finder.raw_possibilities
     white_listed_possibilities = {}
-    raw.each do |source, content|
+    finder.raw_possibilities.each do |source, content|
       possibles = []
       white_list.each do |white_phrase|
         if content.include?(white_phrase)


### PR DESCRIPTION
This PR does two things (both are awesome).

First: It refactors the PossibilityFinder to just share the Ivar of raw_possibilities but not the method that is wrapping service objects.

Second: It adds in a new feature to the black list which removes punctuation and numbers out of content.
